### PR TITLE
Remove git lfs dependency by downloading the data (if needed) from zenodo.

### DIFF
--- a/.github/workflows/book_stable.yml
+++ b/.github/workflows/book_stable.yml
@@ -28,8 +28,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          lfs: true
 
       - name: Cache executed notebooks
         uses: actions/cache@v4

--- a/data/sz_suite_ss/01_Alaska_Peninsula_resscale_2.00.vtu
+++ b/data/sz_suite_ss/01_Alaska_Peninsula_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b0a03d9f1209748fa4678c9cfba3a7c8e2c6b2325f975367f8e314fc977d357
-size 362080

--- a/data/sz_suite_ss/02_Alaska_resscale_2.00.vtu
+++ b/data/sz_suite_ss/02_Alaska_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab914997150e4b9c59e5f94a71cccab4edb2238d711838ae6d651fb36111d974
-size 467220

--- a/data/sz_suite_ss/03_British_Columbia_resscale_2.00.vtu
+++ b/data/sz_suite_ss/03_British_Columbia_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ed0d7bd5c6195f705dc2f085310febdea4885144e2e5876389ae6ccf1d62a40
-size 532360

--- a/data/sz_suite_ss/04_Cascadia_resscale_2.00.vtu
+++ b/data/sz_suite_ss/04_Cascadia_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2620e4f383236dee8b68a454559b5246cc3296042b8f37bf2e2ad7b302f56256
-size 430404

--- a/data/sz_suite_ss/05_Mexico_resscale_2.00.vtu
+++ b/data/sz_suite_ss/05_Mexico_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06cc501784346867725fc66deefdb2e3ee925832464af3e970c4a0e2215aaeb9
-size 383764

--- a/data/sz_suite_ss/06_GuatElSal_resscale_2.00.vtu
+++ b/data/sz_suite_ss/06_GuatElSal_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2778921fc4527469934bbd3108673faed1696d0a54281dafa130b8963149bef5
-size 235412

--- a/data/sz_suite_ss/07_Nicaragua_resscale_2.00.vtu
+++ b/data/sz_suite_ss/07_Nicaragua_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:72b2e10c81effd0debafa8e76bc08c0f19dab677dee30e763c08047bf51b2b59
-size 228595

--- a/data/sz_suite_ss/08_Costa_Rica_resscale_2.00.vtu
+++ b/data/sz_suite_ss/08_Costa_Rica_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:79d9de3728f23231062d7cb912a4e0be8979300b95ceedb0df390e7d5088a319
-size 175292

--- a/data/sz_suite_ss/09_Colombia_Ecuador_resscale_2.00.vtu
+++ b/data/sz_suite_ss/09_Colombia_Ecuador_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd80939f26250e84ad0814ac697ed16a1bf87405e5db2fc007a607349f805104
-size 427579

--- a/data/sz_suite_ss/10_N_Peru_Gap_resscale_2.00.vtu
+++ b/data/sz_suite_ss/10_N_Peru_Gap_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e056f6a7233dbd3e96885ab630747beb1bc9ed77e82c4f756e53bc75d532254
-size 1150016

--- a/data/sz_suite_ss/11_C_Peru_Gap_resscale_2.00.vtu
+++ b/data/sz_suite_ss/11_C_Peru_Gap_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e33b4fefa6095e09daac46c2d71f54fcf490b4ea6f5a6b939695c2da6cc20afe
-size 962880

--- a/data/sz_suite_ss/12_Peru_resscale_2.00.vtu
+++ b/data/sz_suite_ss/12_Peru_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:693283e1e319af2f328338dc77feff5afe6a6d6fd3ebadb0d6ed5e6b82cbf640
-size 496564

--- a/data/sz_suite_ss/13_N_Chile_resscale_2.00.vtu
+++ b/data/sz_suite_ss/13_N_Chile_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0cdc229950514b648dd857e2e28981fc33dd34b905a35e6daee036f6156fe066
-size 465092

--- a/data/sz_suite_ss/14_NC_Chile_resscale_2.00.vtu
+++ b/data/sz_suite_ss/14_NC_Chile_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9eb5e28e792039bd4c15eab26da0da44bd72a08407f448b646b9e51a31006b8b
-size 557355

--- a/data/sz_suite_ss/15_C_Chile_Gap_resscale_2.00.vtu
+++ b/data/sz_suite_ss/15_C_Chile_Gap_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f1ac1a76128dc6bfa50a236c25de5467ab66ecb7bd71e35fda950d9c9ff713a9
-size 929268

--- a/data/sz_suite_ss/16_C_Chile_resscale_2.00.vtu
+++ b/data/sz_suite_ss/16_C_Chile_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3cbd483d540b085ab9455047d6c0b73137368d75544c3e598bddf63ce548f1cd
-size 470532

--- a/data/sz_suite_ss/17_SC_Chile_resscale_2.00.vtu
+++ b/data/sz_suite_ss/17_SC_Chile_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fe6c860f6897074592950e6b97e24e92411383e10d443259f4055638615b2d08
-size 418431

--- a/data/sz_suite_ss/18_S_Chile_resscale_2.00.vtu
+++ b/data/sz_suite_ss/18_S_Chile_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6cf8aa898286eaef437da5bd914b93b9352d8de12225b2f27b7ca00990bf0f8e
-size 341820

--- a/data/sz_suite_ss/19_N_Antilles_resscale_2.00.vtu
+++ b/data/sz_suite_ss/19_N_Antilles_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:672962538d6a73bdf7286422a124ef5f354ecffb92f3c2eea5a9aec1b662aeda
-size 300623

--- a/data/sz_suite_ss/20_S_Antilles_resscale_2.00.vtu
+++ b/data/sz_suite_ss/20_S_Antilles_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d329e11e004f9bcf9ebea06e8fdc0b7beabffeebd17c51c113d2c24ffcf4ba5
-size 320555

--- a/data/sz_suite_ss/21_Scotia_resscale_2.00.vtu
+++ b/data/sz_suite_ss/21_Scotia_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a1f7038de9c01c1b9d4bd0f364cf2f9c8bf2d26c9d318537696529c8fb5bb134
-size 223484

--- a/data/sz_suite_ss/22_Aegean_resscale_2.00.vtu
+++ b/data/sz_suite_ss/22_Aegean_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:46a6935ac5e67bf7b3fc81ebb28824b4ceffcd2f6e42f0e96e72105794db9fae
-size 427196

--- a/data/sz_suite_ss/23_N_Sumatra_resscale_2.00.vtu
+++ b/data/sz_suite_ss/23_N_Sumatra_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8e58beed92029fab6038a19d99147644587be89c36797b9d50772a806bfafea4
-size 381912

--- a/data/sz_suite_ss/24_C_Sumatra_resscale_2.00.vtu
+++ b/data/sz_suite_ss/24_C_Sumatra_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb11dda2528923a7bcdb3f857b1958e94371b8b34f7d04c6166bb80094af9fca
-size 383640

--- a/data/sz_suite_ss/25_S_Sumatra_resscale_2.00.vtu
+++ b/data/sz_suite_ss/25_S_Sumatra_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4fe3d28c9d57c7c7d765d0c9be1fd677f69a42f6e6367cdf87006c37ca33fba6
-size 368188

--- a/data/sz_suite_ss/26_Sunda_Strait_resscale_2.00.vtu
+++ b/data/sz_suite_ss/26_Sunda_Strait_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:944092008be2aa4b84428c8cd6298a3f19a628dad653f7920645151e80fad560
-size 344776

--- a/data/sz_suite_ss/27_Java_resscale_2.00.vtu
+++ b/data/sz_suite_ss/27_Java_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:eaf40b2c578b8fe1872d3f74df712933e6f39499080ed3d0ef1e8f7fdad01a82
-size 343168

--- a/data/sz_suite_ss/28_Bali_Lombok_resscale_2.00.vtu
+++ b/data/sz_suite_ss/28_Bali_Lombok_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bbd5baf8d0daa8cb1485b4d4fd8401f1f5903b81ff084bd675bd09743ffa2949
-size 343120

--- a/data/sz_suite_ss/29_W_Banda_Sea_resscale_2.00.vtu
+++ b/data/sz_suite_ss/29_W_Banda_Sea_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0635fc104e7d01d091a3c0931dabae5eba63172ae54ab47cfe5309734f91c595
-size 334232

--- a/data/sz_suite_ss/30_E_Banda_Sea_resscale_2.00.vtu
+++ b/data/sz_suite_ss/30_E_Banda_Sea_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8969597f753b80d07a7c0f86eb765745981da1897052419a43096a82e24e73e9
-size 331364

--- a/data/sz_suite_ss/31_New_Britain_resscale_2.00.vtu
+++ b/data/sz_suite_ss/31_New_Britain_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7473a03a5b516235c13d534600d366d45bbdebfba8b51e13d65b5a29552a26f5
-size 200464

--- a/data/sz_suite_ss/32_Solomon_resscale_2.00.vtu
+++ b/data/sz_suite_ss/32_Solomon_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bafd31245cf02ceefed723862beab0aaa25d1a00894828bef41cce127ae19937
-size 190524

--- a/data/sz_suite_ss/33_N_Vanuatu_resscale_2.00.vtu
+++ b/data/sz_suite_ss/33_N_Vanuatu_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f275bc3a7bde744b2900121f458f35df658618a1e8587d6124ba4335840a469f
-size 164664

--- a/data/sz_suite_ss/34_S_Vanuatu_resscale_2.00.vtu
+++ b/data/sz_suite_ss/34_S_Vanuatu_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be72b9d4ddea263be11d85aa35bac95a125d4c1cfb1b20e74d367f8886023d4f
-size 173624

--- a/data/sz_suite_ss/35_Tonga_resscale_2.00.vtu
+++ b/data/sz_suite_ss/35_Tonga_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:453b607c246efca69814ea149791e6eed55d7336d6632cbcb4c7efd782a44c14
-size 275459

--- a/data/sz_suite_ss/36_Kermadec_resscale_2.00.vtu
+++ b/data/sz_suite_ss/36_Kermadec_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76f6fb2ed95b9e076832500eb0db30ca0859597fdc1c4fe5939e9ab231508dd2
-size 213204

--- a/data/sz_suite_ss/37_New_Zealand_resscale_2.00.vtu
+++ b/data/sz_suite_ss/37_New_Zealand_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:12e97f3b0320a254a330a578eef38e8e300e009b18b0d3ae36c1d2a729298272
-size 266076

--- a/data/sz_suite_ss/38_S_Phil_resscale_2.00.vtu
+++ b/data/sz_suite_ss/38_S_Phil_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e183cd7d0bf74c448bac97b89aecadb6d7c5e2ca1ba1e8210f1da970557b2ee4
-size 177952

--- a/data/sz_suite_ss/39_N_Phil_resscale_2.00.vtu
+++ b/data/sz_suite_ss/39_N_Phil_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c5ea1d0841c1ebde1f9eff2e1c5b3479aae228f139175a9ebfb2c641f08a8fe
-size 270712

--- a/data/sz_suite_ss/40_S_Marianas_resscale_2.00.vtu
+++ b/data/sz_suite_ss/40_S_Marianas_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:129601d209905588f2f0b5bfbf860c1f8aa6ca43289c9dee8d36650323643e3b
-size 336240

--- a/data/sz_suite_ss/41_N_Marianas_resscale_2.00.vtu
+++ b/data/sz_suite_ss/41_N_Marianas_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db1f48f85175fcc017488fbeaa4238ea6e9f4d5e12603980ddd1385a19b04319
-size 229076

--- a/data/sz_suite_ss/42_Bonin_resscale_2.00.vtu
+++ b/data/sz_suite_ss/42_Bonin_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1971e3c138acdda20d55bfcae4da9e67a8686c88ead568f7077a0b8bef80546b
-size 260212

--- a/data/sz_suite_ss/43_Izu_resscale_2.00.vtu
+++ b/data/sz_suite_ss/43_Izu_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d5308f8ffd2770cd62df22184e0dbad0dced3ddf14f90a26369a79aee8ba04a3
-size 326296

--- a/data/sz_suite_ss/44_Kyushu_resscale_2.00.vtu
+++ b/data/sz_suite_ss/44_Kyushu_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ce8f8981a70d09281f3cb9e90e0da9cb25449b36b90801c706a4134fd37ed29
-size 278015

--- a/data/sz_suite_ss/45_Ryukyu_resscale_2.00.vtu
+++ b/data/sz_suite_ss/45_Ryukyu_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea56d3dcf657f51176a4e85f344735a14ca3588b2f034114fb0bd47ee751a481
-size 314012

--- a/data/sz_suite_ss/46_Nankai_resscale_2.00.vtu
+++ b/data/sz_suite_ss/46_Nankai_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9cbd514fe481ffd1999c99bfe87b6eb066449952a7ff9cacc21bcc7c3f05865
-size 486668

--- a/data/sz_suite_ss/47_C_Honshu_resscale_2.00.vtu
+++ b/data/sz_suite_ss/47_C_Honshu_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b27df9c0e72d823892212d7c5cc00e551abfce064a98429661de3914dafd8170
-size 442576

--- a/data/sz_suite_ss/48_N_Honshu_resscale_2.00.vtu
+++ b/data/sz_suite_ss/48_N_Honshu_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d963501815be0247add546bbd36be3014c1f48f309aff4011fe71f05a6d3255
-size 509752

--- a/data/sz_suite_ss/49_Hokkaido_resscale_2.00.vtu
+++ b/data/sz_suite_ss/49_Hokkaido_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c1096ee8f0bb252b322a1cc769e7c37ef853349b99a041e835819428f81de460
-size 333144

--- a/data/sz_suite_ss/50_S_Kurile_resscale_2.00.vtu
+++ b/data/sz_suite_ss/50_S_Kurile_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24c778f0e84bf1ade9d63e9222fab645d716dfca56fd48d75b8ca51296d31345
-size 310812

--- a/data/sz_suite_ss/51_N_Kurile_resscale_2.00.vtu
+++ b/data/sz_suite_ss/51_N_Kurile_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3426c7821b8cd53fd14c172c93e6cf830310bb73e0b9b9a3c815d0eaa316145c
-size 301972

--- a/data/sz_suite_ss/52_Kamchatka_resscale_2.00.vtu
+++ b/data/sz_suite_ss/52_Kamchatka_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ce80b92e762ba2300a09b238b18dcee3f79790d564439a95e3ef6baa9f391a8
-size 306620

--- a/data/sz_suite_ss/53_W_Aleut_resscale_2.00.vtu
+++ b/data/sz_suite_ss/53_W_Aleut_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98a303ff30a3675881e593306ecca38ce3e570237c89acc68fcf09dd8d61d24c
-size 239064

--- a/data/sz_suite_ss/54_C_Aleut_resscale_2.00.vtu
+++ b/data/sz_suite_ss/54_C_Aleut_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:938440312e6ca6d4e9ff979bd4c8c3e6c016938eafe1b98a14be1ecd4d2dac44
-size 259272

--- a/data/sz_suite_ss/55_E_Aleut_resscale_2.00.vtu
+++ b/data/sz_suite_ss/55_E_Aleut_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e274f9b7afa20d348f27a54abf5e4594568f49b3dc92d7b2b124dd2621682c2
-size 300888

--- a/data/sz_suite_ss/56_Calabria_resscale_2.00.vtu
+++ b/data/sz_suite_ss/56_Calabria_resscale_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80b708b0e76d908b0e788b73d09a000f074d900f1cc6d3fc0591a91ef1476fcd
-size 324984

--- a/data/sz_suite_td/01_Alaska_Peninsula_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/01_Alaska_Peninsula_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d4daa18c8a341dbe98727af28f4ec8fa3f4265d622a3700950810b118d131ba5
-size 361752

--- a/data/sz_suite_td/02_Alaska_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/02_Alaska_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4ccbdf10ab0fdfeece0f86ce8731ae5fddf60f5b3d81d7801e54ca3e17629d76
-size 466896

--- a/data/sz_suite_td/03_British_Columbia_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/03_British_Columbia_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4bc1412a7db5f3dd65f00aea2a88b3dc757200f9f802bf456b5c675c9728fefc
-size 531984

--- a/data/sz_suite_td/04_Cascadia_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/04_Cascadia_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9252f648ea4e0c7d65a0e0fa97e10bbd2f1d5861e56b9fb49b6bb4739c315577
-size 430128

--- a/data/sz_suite_td/05_Mexico_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/05_Mexico_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f8923388e817521ad692fe03931e6e4023a53ec966c3656f92658798a9ab9b8
-size 383500

--- a/data/sz_suite_td/06_GuatElSal_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/06_GuatElSal_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7fd48a57e3d7a2197f6ac3527268b11665b4c8427f83fee66e684268d8d77c1d
-size 235148

--- a/data/sz_suite_td/07_Nicaragua_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/07_Nicaragua_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c23f2d04036e131ab4c7b4bf386fc6a1fc85c70ce3cedd565e39d2117539fb48
-size 228308

--- a/data/sz_suite_td/08_Costa_Rica_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/08_Costa_Rica_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d267aadea6ceb1b8a2033b37c36dd950b23f65eddd91d469b469381ab7f841ff
-size 175004

--- a/data/sz_suite_td/09_Colombia_Ecuador_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/09_Colombia_Ecuador_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:04b05fea661c9d841a8499e233ba9eec9a32d38399490d681be59fef36371c02
-size 427224

--- a/data/sz_suite_td/10_N_Peru_Gap_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/10_N_Peru_Gap_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa3b75d00e96df318e4d8f5c82adcb108665732ce749c2f9c233f8099d10567e
-size 1149228

--- a/data/sz_suite_td/11_C_Peru_Gap_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/11_C_Peru_Gap_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9298efc1f7d044c29ed1f0a28c65f99969214e551bac000e08cc06222b1bd143
-size 961496

--- a/data/sz_suite_td/12_Peru_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/12_Peru_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:984d765ee63f70e3b680a778dcc6e5083921650d931f7e46d3662130ea6eec8c
-size 496012

--- a/data/sz_suite_td/13_N_Chile_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/13_N_Chile_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:085a8580ac1cf1d85056591170cca772566ee98985d6695ab996ec8765ee4da1
-size 464548

--- a/data/sz_suite_td/14_NC_Chile_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/14_NC_Chile_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af2fdfd5b197bf8a9192bde0f5930e28867620cb13e4fbeb1659f674a88f06d0
-size 556744

--- a/data/sz_suite_td/15_C_Chile_Gap_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/15_C_Chile_Gap_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d49a0e18144c21461cc9b5a8567533414780c7a0bf375f91a31a84f1c67c2ed6
-size 928052

--- a/data/sz_suite_td/16_C_Chile_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/16_C_Chile_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:382b8af6511a539abbedc54540abdc0b2bdb7d560c807569ccc0bcd73252a2d8
-size 470140

--- a/data/sz_suite_td/17_SC_Chile_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/17_SC_Chile_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed89604b9e464eea69b05459f4759a1e28fdc5069499ab7a3450f188bfc8a0d6
-size 418176

--- a/data/sz_suite_td/18_S_Chile_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/18_S_Chile_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:77314e95729a9f2f74aa596a72e0bd15dd77817c366033750d1342a980286741
-size 341556

--- a/data/sz_suite_td/19_N_Antilles_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/19_N_Antilles_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:875f38911774ed5f057b0b960f3a41d63c99ce2a1542fe2ce432f35943082c09
-size 300328

--- a/data/sz_suite_td/20_S_Antilles_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/20_S_Antilles_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d545f8cac5186d6325d29b9e5d59cb107ec9f5f0393c9181442e0608be01ff69
-size 320248

--- a/data/sz_suite_td/21_Scotia_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/21_Scotia_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4cf54c158a8534bea6e3095118f9d99d3092d331f2c6e56a0fbb31f341c35385
-size 223012

--- a/data/sz_suite_td/22_Aegean_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/22_Aegean_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:be53e1b9715d9db4b20929a8bdefe1ddbd90b6d11834e884edc24ca67c911fd2
-size 426852

--- a/data/sz_suite_td/23_N_Sumatra_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/23_N_Sumatra_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d2a5a93e1b3b271ec37d9a64ad7f7643f9238e6de5a6591754f41a0dd8503781
-size 381616

--- a/data/sz_suite_td/24_C_Sumatra_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/24_C_Sumatra_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d6897fff806953ea2edc9fef84eadd37ac6c6fe7e892ad2a988dea2d5ccfc888
-size 383312

--- a/data/sz_suite_td/25_S_Sumatra_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/25_S_Sumatra_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82d57dc9b850fc19f490e406bcabbb1ecb44e698c8cda1ddf703248f0207710e
-size 367888

--- a/data/sz_suite_td/26_Sunda_Strait_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/26_Sunda_Strait_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f97028dc5bf1c73f5103a9250ead24c68dacc306545f82cdf753d61a8d260585
-size 344540

--- a/data/sz_suite_td/27_Java_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/27_Java_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d4a79b1b74fbb6bce2f8677e928512dfd78737275ccd19af86aef78cea7663f
-size 342860

--- a/data/sz_suite_td/28_Bali_Lombok_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/28_Bali_Lombok_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e6725840f623bca054ca35909e6a7eeb0df3078d96a2b7b7ed13f3d44cf1f8c0
-size 342832

--- a/data/sz_suite_td/29_W_Banda_Sea_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/29_W_Banda_Sea_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dfec4580daec2ac97df84b5c4d6a298119efe9b6e062e1b45ecc5a157fdc178b
-size 333956

--- a/data/sz_suite_td/30_E_Banda_Sea_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/30_E_Banda_Sea_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:768acdf9a6f5709bc38c812ee21b793965922ee63f88b925e6f888d5746da164
-size 331140

--- a/data/sz_suite_td/31_New_Britain_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/31_New_Britain_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:044d402ed3c050b963c1f8331cda6052ebdecbbaa428030cdb25e487dffc4bec
-size 200060

--- a/data/sz_suite_td/32_Solomon_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/32_Solomon_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d161af66e1374f1cc62c2be408658ed72354cf8eea48f28b510dc7acc836a6d3
-size 190244

--- a/data/sz_suite_td/33_N_Vanuatu_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/33_N_Vanuatu_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:62d491d8ea9f70e9b711109d3b3ad4dc23b65a1bea27983703f41fea8e7b5c03
-size 164328

--- a/data/sz_suite_td/34_S_Vanuatu_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/34_S_Vanuatu_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:37cc1e8c6868afe6dc9b174cf472a42879c72562366b8c26fb54f452a3bba5b7
-size 173208

--- a/data/sz_suite_td/35_Tonga_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/35_Tonga_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14941ce95ea8d97b78fe89a1d8c5701b54dbe2127ec31ba44125a9dd2c1dc12a
-size 275032

--- a/data/sz_suite_td/36_Kermadec_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/36_Kermadec_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b92d4b32223d7c8e42e78636786f4a76014f66e6bf8fa090288c0b5014fc8c88
-size 212884

--- a/data/sz_suite_td/37_New_Zealand_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/37_New_Zealand_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5e1f6e6c45ec4ae92710449f1accca0e65c2ba19a3101bc1cda32c7060eb5bac
-size 265788

--- a/data/sz_suite_td/38_S_Phil_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/38_S_Phil_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08e853d3f26e44a11352c82746f6f2658e70aa498fac1689f712e590a9c925c1
-size 177668

--- a/data/sz_suite_td/39_N_Phil_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/39_N_Phil_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0d3bdce941190d9c213858c4a8648972f969c5d8ba6657be6669cc1f211634c
-size 270380

--- a/data/sz_suite_td/40_S_Marianas_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/40_S_Marianas_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:26c1ab81c34a49b4852f98cf2254ca07e234e78beb91399d685b14c3ec462806
-size 335912

--- a/data/sz_suite_td/41_N_Marianas_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/41_N_Marianas_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2069e89ea02c0ab6db5088c92e30e4d274b991f1ecc96c64cf066ba3b6e5d571
-size 228776

--- a/data/sz_suite_td/42_Bonin_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/42_Bonin_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c866301d03559c624639e1f9c3f19953a46b6dd7800d766632dbbc2074acb9a
-size 259948

--- a/data/sz_suite_td/43_Izu_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/43_Izu_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97e799fd8dd76cd278415567d15e5695eb487f37b4c0ab3670b91e51daccf469
-size 326000

--- a/data/sz_suite_td/44_Kyushu_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/44_Kyushu_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b80140273609693174273c19f534f3ef113abcafa73f90dfa0ebe54da5fb4f60
-size 277764

--- a/data/sz_suite_td/45_Ryukyu_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/45_Ryukyu_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:99d6138e6ac0a3e7854d6b69f4dbdd87b7d992d8d20558e88b46437eb10d04f4
-size 313684

--- a/data/sz_suite_td/46_Nankai_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/46_Nankai_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1495eaf1ef9ca6c596502b1db1abee6a152e1e45e727a17d00dfd3188967461b
-size 486236

--- a/data/sz_suite_td/47_C_Honshu_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/47_C_Honshu_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1992d46ca28441ba988b5f6aa089a2bdd70b952dcf2ee8a5b4fc6f7a91a3dbe
-size 442204

--- a/data/sz_suite_td/48_N_Honshu_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/48_N_Honshu_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9778d7d4ca8a01fe6a42a8c40d26a136e8d97403c3384bbbfa38917b48d038a
-size 509412

--- a/data/sz_suite_td/49_Hokkaido_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/49_Hokkaido_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:784247e053e6666ad3863b97b5b311daed03e48b12114cc67663a7e3d424482c
-size 332832

--- a/data/sz_suite_td/50_S_Kurile_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/50_S_Kurile_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f842a29439f3de944f3a50d6e93fe9765b6095e85395ad0c7fd234c5ca57511e
-size 310456

--- a/data/sz_suite_td/51_N_Kurile_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/51_N_Kurile_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f44281323ec60dc8dc86519cc45747119ae9c18ffceb0377b3b66489eede2159
-size 301672

--- a/data/sz_suite_td/52_Kamchatka_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/52_Kamchatka_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f2ae649d6466b5dd8d5c21ca94496ff2ef781f196bf23f4bc357e4a83ff25bc6
-size 306308

--- a/data/sz_suite_td/53_W_Aleut_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/53_W_Aleut_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ab44f19a44cb93ad9d805fe559d48539ecefdc3a312dad1dee5878cb88f213c
-size 238780

--- a/data/sz_suite_td/54_C_Aleut_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/54_C_Aleut_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b4f1e24ea84efe5b2d5fef2492b66c9267a1bd42e26e268136110f4857aebfb
-size 259000

--- a/data/sz_suite_td/55_E_Aleut_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/55_E_Aleut_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef1170410ce0b277458911b45884e712e9970f820dafd4fcd46c25d3a9f097fa
-size 300572

--- a/data/sz_suite_td/56_Calabria_resscale_2.00_cfl_2.00.vtu
+++ b/data/sz_suite_td/56_Calabria_resscale_2.00_cfl_2.00.vtu
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9041fbb0c95c518449d5444f23789979d39db11ddfec797e3e8119fe5643ed88
-size 324652

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ ENV PYVISTA_JUPYTER_BACKEND="static"
 WORKDIR /tmp/
 # Requirements for pyvista (gl1 and render1) and jupyterlab (nodejs and curl)
 RUN apt-get update && \
-    apt-get install -y libgl1-mesa-glx libxrender1 xvfb curl vim ack zip git-lfs && \
+    apt-get install -y libgl1-mesa-glx libxrender1 xvfb curl vim ack zip && \
     curl -sL https://deb.nodesource.com/setup_18.x -o nodesource_setup.sh && \
     bash nodesource_setup.sh && \
     apt install nodejs && \

--- a/notebooks/sz_suite_ss/01_Alaska_Peninsula.ipynb
+++ b/notebooks/sz_suite_ss/01_Alaska_Peninsula.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/01_Alaska_Peninsula.py
+++ b/notebooks/sz_suite_ss/01_Alaska_Peninsula.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/02_Alaska.ipynb
+++ b/notebooks/sz_suite_ss/02_Alaska.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/02_Alaska.py
+++ b/notebooks/sz_suite_ss/02_Alaska.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/03_British_Columbia.ipynb
+++ b/notebooks/sz_suite_ss/03_British_Columbia.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/03_British_Columbia.py
+++ b/notebooks/sz_suite_ss/03_British_Columbia.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/04_Cascadia.ipynb
+++ b/notebooks/sz_suite_ss/04_Cascadia.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/04_Cascadia.py
+++ b/notebooks/sz_suite_ss/04_Cascadia.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/05_Mexico.ipynb
+++ b/notebooks/sz_suite_ss/05_Mexico.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/05_Mexico.py
+++ b/notebooks/sz_suite_ss/05_Mexico.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/06_GuatElSal.ipynb
+++ b/notebooks/sz_suite_ss/06_GuatElSal.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/06_GuatElSal.py
+++ b/notebooks/sz_suite_ss/06_GuatElSal.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/07_Nicaragua.ipynb
+++ b/notebooks/sz_suite_ss/07_Nicaragua.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/07_Nicaragua.py
+++ b/notebooks/sz_suite_ss/07_Nicaragua.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/08_Costa_Rica.ipynb
+++ b/notebooks/sz_suite_ss/08_Costa_Rica.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/08_Costa_Rica.py
+++ b/notebooks/sz_suite_ss/08_Costa_Rica.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/09_Colombia_Ecuador.ipynb
+++ b/notebooks/sz_suite_ss/09_Colombia_Ecuador.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/09_Colombia_Ecuador.py
+++ b/notebooks/sz_suite_ss/09_Colombia_Ecuador.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/10_N_Peru_Gap.ipynb
+++ b/notebooks/sz_suite_ss/10_N_Peru_Gap.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/10_N_Peru_Gap.py
+++ b/notebooks/sz_suite_ss/10_N_Peru_Gap.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/11_C_Peru_Gap.ipynb
+++ b/notebooks/sz_suite_ss/11_C_Peru_Gap.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/11_C_Peru_Gap.py
+++ b/notebooks/sz_suite_ss/11_C_Peru_Gap.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/12_Peru.ipynb
+++ b/notebooks/sz_suite_ss/12_Peru.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/12_Peru.py
+++ b/notebooks/sz_suite_ss/12_Peru.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/13_N_Chile.ipynb
+++ b/notebooks/sz_suite_ss/13_N_Chile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/13_N_Chile.py
+++ b/notebooks/sz_suite_ss/13_N_Chile.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/14_NC_Chile.ipynb
+++ b/notebooks/sz_suite_ss/14_NC_Chile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/14_NC_Chile.py
+++ b/notebooks/sz_suite_ss/14_NC_Chile.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/15_C_Chile_Gap.ipynb
+++ b/notebooks/sz_suite_ss/15_C_Chile_Gap.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/15_C_Chile_Gap.py
+++ b/notebooks/sz_suite_ss/15_C_Chile_Gap.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/16_C_Chile.ipynb
+++ b/notebooks/sz_suite_ss/16_C_Chile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/16_C_Chile.py
+++ b/notebooks/sz_suite_ss/16_C_Chile.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/17_SC_Chile.ipynb
+++ b/notebooks/sz_suite_ss/17_SC_Chile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/17_SC_Chile.py
+++ b/notebooks/sz_suite_ss/17_SC_Chile.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/18_S_Chile.ipynb
+++ b/notebooks/sz_suite_ss/18_S_Chile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/18_S_Chile.py
+++ b/notebooks/sz_suite_ss/18_S_Chile.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/19_N_Antilles.ipynb
+++ b/notebooks/sz_suite_ss/19_N_Antilles.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/19_N_Antilles.py
+++ b/notebooks/sz_suite_ss/19_N_Antilles.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/20_S_Antilles.ipynb
+++ b/notebooks/sz_suite_ss/20_S_Antilles.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/20_S_Antilles.py
+++ b/notebooks/sz_suite_ss/20_S_Antilles.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/21_Scotia.ipynb
+++ b/notebooks/sz_suite_ss/21_Scotia.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/21_Scotia.py
+++ b/notebooks/sz_suite_ss/21_Scotia.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/22_Aegean.ipynb
+++ b/notebooks/sz_suite_ss/22_Aegean.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/22_Aegean.py
+++ b/notebooks/sz_suite_ss/22_Aegean.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/23_N_Sumatra.ipynb
+++ b/notebooks/sz_suite_ss/23_N_Sumatra.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/23_N_Sumatra.py
+++ b/notebooks/sz_suite_ss/23_N_Sumatra.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/24_C_Sumatra.ipynb
+++ b/notebooks/sz_suite_ss/24_C_Sumatra.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/24_C_Sumatra.py
+++ b/notebooks/sz_suite_ss/24_C_Sumatra.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/25_S_Sumatra.ipynb
+++ b/notebooks/sz_suite_ss/25_S_Sumatra.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/25_S_Sumatra.py
+++ b/notebooks/sz_suite_ss/25_S_Sumatra.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/26_Sunda_Strait.ipynb
+++ b/notebooks/sz_suite_ss/26_Sunda_Strait.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/26_Sunda_Strait.py
+++ b/notebooks/sz_suite_ss/26_Sunda_Strait.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/27_Java.ipynb
+++ b/notebooks/sz_suite_ss/27_Java.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/27_Java.py
+++ b/notebooks/sz_suite_ss/27_Java.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/28_Bali_Lombok.ipynb
+++ b/notebooks/sz_suite_ss/28_Bali_Lombok.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/28_Bali_Lombok.py
+++ b/notebooks/sz_suite_ss/28_Bali_Lombok.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/29_W_Banda_Sea.ipynb
+++ b/notebooks/sz_suite_ss/29_W_Banda_Sea.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/29_W_Banda_Sea.py
+++ b/notebooks/sz_suite_ss/29_W_Banda_Sea.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/30_E_Banda_Sea.ipynb
+++ b/notebooks/sz_suite_ss/30_E_Banda_Sea.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/30_E_Banda_Sea.py
+++ b/notebooks/sz_suite_ss/30_E_Banda_Sea.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/31_New_Britain.ipynb
+++ b/notebooks/sz_suite_ss/31_New_Britain.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/31_New_Britain.py
+++ b/notebooks/sz_suite_ss/31_New_Britain.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/32_Solomon.ipynb
+++ b/notebooks/sz_suite_ss/32_Solomon.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/32_Solomon.py
+++ b/notebooks/sz_suite_ss/32_Solomon.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/33_N_Vanuatu.ipynb
+++ b/notebooks/sz_suite_ss/33_N_Vanuatu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/33_N_Vanuatu.py
+++ b/notebooks/sz_suite_ss/33_N_Vanuatu.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/34_S_Vanuatu.ipynb
+++ b/notebooks/sz_suite_ss/34_S_Vanuatu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/34_S_Vanuatu.py
+++ b/notebooks/sz_suite_ss/34_S_Vanuatu.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/35_Tonga.ipynb
+++ b/notebooks/sz_suite_ss/35_Tonga.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/35_Tonga.py
+++ b/notebooks/sz_suite_ss/35_Tonga.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/36_Kermadec.ipynb
+++ b/notebooks/sz_suite_ss/36_Kermadec.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/36_Kermadec.py
+++ b/notebooks/sz_suite_ss/36_Kermadec.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/37_New_Zealand.ipynb
+++ b/notebooks/sz_suite_ss/37_New_Zealand.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/37_New_Zealand.py
+++ b/notebooks/sz_suite_ss/37_New_Zealand.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/38_S_Philippines.ipynb
+++ b/notebooks/sz_suite_ss/38_S_Philippines.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/38_S_Philippines.py
+++ b/notebooks/sz_suite_ss/38_S_Philippines.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/39_N_Philippines.ipynb
+++ b/notebooks/sz_suite_ss/39_N_Philippines.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/39_N_Philippines.py
+++ b/notebooks/sz_suite_ss/39_N_Philippines.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/40_S_Marianas.ipynb
+++ b/notebooks/sz_suite_ss/40_S_Marianas.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/40_S_Marianas.py
+++ b/notebooks/sz_suite_ss/40_S_Marianas.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/41_N_Marianas.ipynb
+++ b/notebooks/sz_suite_ss/41_N_Marianas.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/41_N_Marianas.py
+++ b/notebooks/sz_suite_ss/41_N_Marianas.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/42_Bonin.ipynb
+++ b/notebooks/sz_suite_ss/42_Bonin.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/42_Bonin.py
+++ b/notebooks/sz_suite_ss/42_Bonin.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/43_Izu.ipynb
+++ b/notebooks/sz_suite_ss/43_Izu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/43_Izu.py
+++ b/notebooks/sz_suite_ss/43_Izu.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/44_Kyushu.ipynb
+++ b/notebooks/sz_suite_ss/44_Kyushu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/44_Kyushu.py
+++ b/notebooks/sz_suite_ss/44_Kyushu.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/45_Ryukyu.ipynb
+++ b/notebooks/sz_suite_ss/45_Ryukyu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/45_Ryukyu.py
+++ b/notebooks/sz_suite_ss/45_Ryukyu.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/46_Nankai.ipynb
+++ b/notebooks/sz_suite_ss/46_Nankai.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/46_Nankai.py
+++ b/notebooks/sz_suite_ss/46_Nankai.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/47_C_Honshu.ipynb
+++ b/notebooks/sz_suite_ss/47_C_Honshu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/47_C_Honshu.py
+++ b/notebooks/sz_suite_ss/47_C_Honshu.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/48_N_Honshu.ipynb
+++ b/notebooks/sz_suite_ss/48_N_Honshu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/48_N_Honshu.py
+++ b/notebooks/sz_suite_ss/48_N_Honshu.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/49_Hokkaido.ipynb
+++ b/notebooks/sz_suite_ss/49_Hokkaido.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/49_Hokkaido.py
+++ b/notebooks/sz_suite_ss/49_Hokkaido.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/50_S_Kurile.ipynb
+++ b/notebooks/sz_suite_ss/50_S_Kurile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/50_S_Kurile.py
+++ b/notebooks/sz_suite_ss/50_S_Kurile.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/51_N_Kurile.ipynb
+++ b/notebooks/sz_suite_ss/51_N_Kurile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/51_N_Kurile.py
+++ b/notebooks/sz_suite_ss/51_N_Kurile.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/52_Kamchatka.ipynb
+++ b/notebooks/sz_suite_ss/52_Kamchatka.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/52_Kamchatka.py
+++ b/notebooks/sz_suite_ss/52_Kamchatka.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/53_W_Aleutians.ipynb
+++ b/notebooks/sz_suite_ss/53_W_Aleutians.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/53_W_Aleutians.py
+++ b/notebooks/sz_suite_ss/53_W_Aleutians.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/54_C_Aleutians.ipynb
+++ b/notebooks/sz_suite_ss/54_C_Aleutians.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/54_C_Aleutians.py
+++ b/notebooks/sz_suite_ss/54_C_Aleutians.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/55_E_Aleutians.ipynb
+++ b/notebooks/sz_suite_ss/55_E_Aleutians.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/55_E_Aleutians.py
+++ b/notebooks/sz_suite_ss/55_E_Aleutians.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/56_Calabria.ipynb
+++ b/notebooks/sz_suite_ss/56_Calabria.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_ss/56_Calabria.py
+++ b/notebooks/sz_suite_ss/56_Calabria.py
@@ -39,6 +39,9 @@ if __name__ == "__main__" and "__file__" in globals():
 import pathlib
 output_folder = pathlib.Path(os.path.join(basedir, "output"))
 output_folder.mkdir(exist_ok=True, parents=True)
+import hashlib
+import zipfile
+import requests
 
 
 # ### Parameters
@@ -153,16 +156,37 @@ if __name__ == "__main__" and "__file__" not in globals():
 # ## Comparison
 
 # Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).
+# 
+# First download the minimal necessary data from zenodo and check it is the right version.
+
+# In[ ]:
+
+
+zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, "data", "vankeken_wilson_peps_2023_TF_lowres_minimal.zip"))
+if not zipfilename.is_file():
+    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'
+    r = requests.get(zipfileurl, allow_redirects=True)
+    open(zipfilename, 'wb').write(r.content)
+assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'
+
+
+# In[ ]:
+
+
+tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')
+tffilepath = os.path.join(os.pardir, os.pardir, 'data')
+with zipfile.ZipFile(zipfilename, 'r') as z:
+    z.extract(tffilename, path=tffilepath)
+
 
 # In[ ]:
 
 
 fxgrid = utils.grids_scalar(sz.T_i)[0]
 
-tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')
-tfgrid = pv.get_reader(tffilename).read()
+tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()
 
-diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':"Temperature::PotentialTemperature"}, pass_point_data=True)
+diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)
 
 
 # In[ ]:

--- a/notebooks/sz_suite_ss/template.ipynb
+++ b/notebooks/sz_suite_ss/template.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -319,22 +322,51 @@
    "id": "7a6b164f-0ea5-49b4-9262-ef44cc054dff",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54a2636b-33ba-4c16-bd25-bace8a84095f",
+   "id": "e40a1895-9ce1-4580-90f3-d4b2580ad10b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7387486-002f-4be5-b1ec-18491d9faf99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_ss', szdict['dirname']+'_minres_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28490f19-fb30-44ca-b965-f0d0e379b8c3",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_ss', szdict['dirname']+'_resscale_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/01_Alaska_Peninsula.ipynb
+++ b/notebooks/sz_suite_td/01_Alaska_Peninsula.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/02_Alaska.ipynb
+++ b/notebooks/sz_suite_td/02_Alaska.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/03_British_Columbia.ipynb
+++ b/notebooks/sz_suite_td/03_British_Columbia.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/04_Cascadia.ipynb
+++ b/notebooks/sz_suite_td/04_Cascadia.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/05_Mexico.ipynb
+++ b/notebooks/sz_suite_td/05_Mexico.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/06_GuatElSal.ipynb
+++ b/notebooks/sz_suite_td/06_GuatElSal.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/07_Nicaragua.ipynb
+++ b/notebooks/sz_suite_td/07_Nicaragua.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/08_Costa_Rica.ipynb
+++ b/notebooks/sz_suite_td/08_Costa_Rica.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/09_Colombia_Ecuador.ipynb
+++ b/notebooks/sz_suite_td/09_Colombia_Ecuador.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/10_N_Peru_Gap.ipynb
+++ b/notebooks/sz_suite_td/10_N_Peru_Gap.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/11_C_Peru_Gap.ipynb
+++ b/notebooks/sz_suite_td/11_C_Peru_Gap.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/12_Peru.ipynb
+++ b/notebooks/sz_suite_td/12_Peru.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/13_N_Chile.ipynb
+++ b/notebooks/sz_suite_td/13_N_Chile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/14_NC_Chile.ipynb
+++ b/notebooks/sz_suite_td/14_NC_Chile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/15_C_Chile_Gap.ipynb
+++ b/notebooks/sz_suite_td/15_C_Chile_Gap.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/16_C_Chile.ipynb
+++ b/notebooks/sz_suite_td/16_C_Chile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/17_SC_Chile.ipynb
+++ b/notebooks/sz_suite_td/17_SC_Chile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/18_S_Chile.ipynb
+++ b/notebooks/sz_suite_td/18_S_Chile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/19_N_Antilles.ipynb
+++ b/notebooks/sz_suite_td/19_N_Antilles.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/20_S_Antilles.ipynb
+++ b/notebooks/sz_suite_td/20_S_Antilles.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/21_Scotia.ipynb
+++ b/notebooks/sz_suite_td/21_Scotia.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/22_Aegean.ipynb
+++ b/notebooks/sz_suite_td/22_Aegean.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/23_N_Sumatra.ipynb
+++ b/notebooks/sz_suite_td/23_N_Sumatra.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/24_C_Sumatra.ipynb
+++ b/notebooks/sz_suite_td/24_C_Sumatra.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/25_S_Sumatra.ipynb
+++ b/notebooks/sz_suite_td/25_S_Sumatra.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/26_Sunda_Strait.ipynb
+++ b/notebooks/sz_suite_td/26_Sunda_Strait.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/27_Java.ipynb
+++ b/notebooks/sz_suite_td/27_Java.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/28_Bali_Lombok.ipynb
+++ b/notebooks/sz_suite_td/28_Bali_Lombok.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/29_W_Banda_Sea.ipynb
+++ b/notebooks/sz_suite_td/29_W_Banda_Sea.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/30_E_Banda_Sea.ipynb
+++ b/notebooks/sz_suite_td/30_E_Banda_Sea.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/31_New_Britain.ipynb
+++ b/notebooks/sz_suite_td/31_New_Britain.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/32_Solomon.ipynb
+++ b/notebooks/sz_suite_td/32_Solomon.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/33_N_Vanuatu.ipynb
+++ b/notebooks/sz_suite_td/33_N_Vanuatu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/34_S_Vanuatu.ipynb
+++ b/notebooks/sz_suite_td/34_S_Vanuatu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/35_Tonga.ipynb
+++ b/notebooks/sz_suite_td/35_Tonga.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/36_Kermadec.ipynb
+++ b/notebooks/sz_suite_td/36_Kermadec.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/37_New_Zealand.ipynb
+++ b/notebooks/sz_suite_td/37_New_Zealand.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/38_S_Philippines.ipynb
+++ b/notebooks/sz_suite_td/38_S_Philippines.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/39_N_Philippines.ipynb
+++ b/notebooks/sz_suite_td/39_N_Philippines.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/40_S_Marianas.ipynb
+++ b/notebooks/sz_suite_td/40_S_Marianas.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/41_N_Marianas.ipynb
+++ b/notebooks/sz_suite_td/41_N_Marianas.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/42_Bonin.ipynb
+++ b/notebooks/sz_suite_td/42_Bonin.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/43_Izu.ipynb
+++ b/notebooks/sz_suite_td/43_Izu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/44_Kyushu.ipynb
+++ b/notebooks/sz_suite_td/44_Kyushu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/45_Ryukyu.ipynb
+++ b/notebooks/sz_suite_td/45_Ryukyu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/46_Nankai.ipynb
+++ b/notebooks/sz_suite_td/46_Nankai.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/47_C_Honshu.ipynb
+++ b/notebooks/sz_suite_td/47_C_Honshu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/48_N_Honshu.ipynb
+++ b/notebooks/sz_suite_td/48_N_Honshu.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/49_Hokkaido.ipynb
+++ b/notebooks/sz_suite_td/49_Hokkaido.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/50_S_Kurile.ipynb
+++ b/notebooks/sz_suite_td/50_S_Kurile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/51_N_Kurile.ipynb
+++ b/notebooks/sz_suite_td/51_N_Kurile.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/52_Kamchatka.ipynb
+++ b/notebooks/sz_suite_td/52_Kamchatka.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/53_W_Aleutians.ipynb
+++ b/notebooks/sz_suite_td/53_W_Aleutians.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/54_C_Aleutians.ipynb
+++ b/notebooks/sz_suite_td/54_C_Aleutians.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/55_E_Aleutians.ipynb
+++ b/notebooks/sz_suite_td/55_E_Aleutians.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/56_Calabria.ipynb
+++ b/notebooks/sz_suite_td/56_Calabria.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {

--- a/notebooks/sz_suite_td/template.ipynb
+++ b/notebooks/sz_suite_td/template.ipynb
@@ -75,7 +75,10 @@
     "    pv.OFF_SCREEN = True\n",
     "import pathlib\n",
     "output_folder = pathlib.Path(os.path.join(basedir, \"output\"))\n",
-    "output_folder.mkdir(exist_ok=True, parents=True)"
+    "output_folder.mkdir(exist_ok=True, parents=True)\n",
+    "import hashlib\n",
+    "import zipfile\n",
+    "import requests"
    ]
   },
   {
@@ -321,25 +324,54 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddb42203-49a8-4c78-870c-604451feecd0",
+   "id": "3b85397f-de65-4915-bc1e-089ac8120372",
    "metadata": {},
    "source": [
-    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967)."
+    "Compare to the published result from [Wilson & van Keken, PEPS, 2023 (II)](http://dx.doi.org/10.1186/s40645-023-00588-6) and [van Keken & Wilson, PEPS, 2023 (III)](https://doi.org/10.1186/s40645-023-00589-5).  The original models used in these papers are also available as open-source repositories on [github](https://github.com/cianwilson/vankeken_wilson_peps_2023) and [zenodo](https://doi.org/10.5281/zenodo.7843967).\n",
+    "\n",
+    "First download the minimal necessary data from zenodo and check it is the right version."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f11db6b-df77-4ed6-9271-8120caee13f9",
+   "id": "607acc4b-2e34-4761-972f-15df35b90b08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zipfilename = pathlib.Path(os.path.join(basedir, os.path.pardir, os.path.pardir, \"data\", \"vankeken_wilson_peps_2023_TF_lowres_minimal.zip\"))\n",
+    "if not zipfilename.is_file():\n",
+    "    zipfileurl = 'https://zenodo.org/records/13234021/files/vankeken_wilson_peps_2023_TF_lowres_minimal.zip'\n",
+    "    r = requests.get(zipfileurl, allow_redirects=True)\n",
+    "    open(zipfilename, 'wb').write(r.content)\n",
+    "assert hashlib.md5(open(zipfilename, 'rb').read()).hexdigest() == 'a8eca6220f9bee091e41a680d502fe0d'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90ddd8f9-dc97-45ce-af5f-ea4e8d2edd2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tffilename = os.path.join('vankeken_wilson_peps_2023_TF_lowres_minimal', 'sz_suite_td', szdict['dirname']+'_minres_2.00_cfl_2.00.vtu')\n",
+    "tffilepath = os.path.join(os.pardir, os.pardir, 'data')\n",
+    "with zipfile.ZipFile(zipfilename, 'r') as z:\n",
+    "    z.extract(tffilename, path=tffilepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bad57643-20c0-4317-b96d-c6b821731b1e",
    "metadata": {},
    "outputs": [],
    "source": [
     "fxgrid = utils.grids_scalar(sz.T_i)[0]\n",
     "\n",
-    "tffilename = os.path.join(os.pardir, os.pardir, 'data', 'sz_suite_td', szdict['dirname']+'_resscale_2.00_cfl_2.00.vtu')\n",
-    "tfgrid = pv.get_reader(tffilename).read()\n",
+    "tfgrid = pv.get_reader(os.path.join(tffilepath, tffilename)).read()\n",
     "\n",
-    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':\"Temperature::PotentialTemperature\"}, pass_point_data=True)"
+    "diffgrid = utils.pv_diff(fxgrid, tfgrid, field_name_map={'T':'Temperature::PotentialTemperature'}, pass_point_data=True)"
    ]
   },
   {


### PR DESCRIPTION
Can't sustain bandwidth requirements of git lfs so let's use zenodo instead.